### PR TITLE
Update and sync format_options with Vinyl, new YA locations

### DIFF
--- a/config/settings/opac_tc_light.yml
+++ b/config/settings/opac_tc_light.yml
@@ -12,7 +12,7 @@ shelf_lock:
   default_activated: false
   text: 'Limit to Adult at Woodmere'
 location_name: 'Traverse City Library | Traverse Area District Library'
-format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['Music - Vinyl','shelving_location','533'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802'],['Sheet Music','shelving_location','575']]
+format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['Music - Vinyl','shelving_location','533'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802,998,999,1000,1052,1053,1054'],['Sheet Music','shelving_location','575']]
 #format_options_unlocked: [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j']]
 format_label: 'Format'
 #format_label_unlocked: 'Format'

--- a/config/settings/opac_tc_registration_light.yml
+++ b/config/settings/opac_tc_registration_light.yml
@@ -12,7 +12,7 @@ shelf_lock:
   default_activated: false
   text: 'Limit to Adult at Woodmere'
 location_name: 'Traverse City Library | Traverse Area District Library'
-format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['Music - Vinyl','shelving_location','533'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802'],['Sheet Music','shelving_location','575']]
+format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['Music - Vinyl','shelving_location','533'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802,998,999,1000,1052,1053,1054'],['Sheet Music','shelving_location','575']]
 #format_options_unlocked: [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j']]
 format_label: 'Format'
 #format_label_unlocked: 'Format'

--- a/config/settings/opac_tc_registration_light.yml
+++ b/config/settings/opac_tc_registration_light.yml
@@ -12,7 +12,7 @@ shelf_lock:
   default_activated: false
   text: 'Limit to Adult at Woodmere'
 location_name: 'Traverse City Library | Traverse Area District Library'
-format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802'],['Sheet Music','shelving_location','575']]
+format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['Music - Vinyl','shelving_location','533'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802'],['Sheet Music','shelving_location','575']]
 #format_options_unlocked: [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j']]
 format_label: 'Format'
 #format_label_unlocked: 'Format'

--- a/config/settings/opac_tc_teen_light.yml
+++ b/config/settings/opac_tc_teen_light.yml
@@ -12,7 +12,7 @@ shelf_lock:
   default_activated: false
   text: 'Limit to Adult at Woodmere'
 location_name: 'Traverse City Library | Traverse Area District Library'
-format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['Music - Vinyl','shelving_location','533'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802'],['Sheet Music','shelving_location','575']]
+format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['Music - Vinyl','shelving_location','533'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802,998,999,1000,1052,1053,1054'],['Sheet Music','shelving_location','575']]
 #format_options_unlocked: [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j']]
 format_label: 'Format'
 #format_label_unlocked: 'Format'

--- a/config/settings/opac_test.yml
+++ b/config/settings/opac_test.yml
@@ -11,7 +11,7 @@ shelf_lock:
   default_activated: false
   text: 'Limit to Adult at Woodmere'
 location_name: 'Traverse City Library | Traverse Area District Library'
-format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802'],['Sheet Music','shelving_location','575']]
+format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802,998,999,1000,1052,1053,1054'],['Sheet Music','shelving_location','575']]
 #format_options_unlocked: [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j']]
 format_label: 'Format'
 #format_label_unlocked: 'Format'

--- a/config/settings/summer_test.yml
+++ b/config/settings/summer_test.yml
@@ -14,7 +14,7 @@ shelf_lock:
   default_activated: false
   text: 'Limit to Adult at Woodmere'
 location_name: 'Woodmere (Main) Branch | Traverse Area District Library'
-format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802'],['Sheet Music','shelving_location','575'],['Music - Vinyl','shelving_location','533']]
+format_options:  [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Large Print', 'shelving_location', '534'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j'],['CD Audiobooks', 'shelving_location', '518,584'],['MP3 CD Audiobooks', 'shelving_location', '680'],['Playaway Audiobooks','shelving_location','546,590'],['Youth', 'shelving_location', '981,978,977,979,980,516,593,527,571,770,771,529,528,791,530,792,531,795,794,793,532,542,589,549,670'],['Teen','shelving_location','786,787,572,563,564,565,566,802,998,999,1000,1052,1053,1054'],['Sheet Music','shelving_location','575'],['Music - Vinyl','shelving_location','533']]
 #format_options_unlocked: [['All Formats', 'fmt' ,'all'], ['Books', 'fmt' ,'a'],['Movies / TV', 'fmt' ,'g'],['Music', 'fmt' ,'j']]
 format_label: 'Format'
 #format_label_unlocked: 'Format'


### PR DESCRIPTION
Updating configs for new YA locations and to add Vinyl to the TC "registration" OPAC.

The "Teen" format was updated with newly-added YA shelving locations anywhere the Teen format currently appears.