### PR TITLE
Disable autocomplete/caps on forgot password input

### DIFF
--- a/app/views/main/password_reset.html.erb
+++ b/app/views/main/password_reset.html.erb
@@ -19,7 +19,7 @@
                         <div class="form-group input-group">
                             <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
                             <label class="sr-only" for="passuser"><% if Settings.password_reset_inputs != 'card_only' %>Username or <% end %>Card Number</label>
-                            <input type="text" class="form-control" id="passuser" name="passuser" placeholder="<% if Settings.password_reset_inputs != 'card_only' %>Username or <% end %>Card #" required>
+                            <input type="text" class="form-control" id="passuser" name="passuser" autocapitalize="none" autocorrect="off" placeholder="<% if Settings.password_reset_inputs != 'card_only' %>Username or <% end %>Card #" required>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Disable autocomplete and autocapitalization of the input field on
the forgot password form.

This matches the attributes of the actual username field on the
login form/page, and should improve password reset request success
rate.