### PR TITLE
Fix actual user-facing password reset input

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,7 +57,7 @@
                         <div class="form-group input-group">
                             <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
                             <label class="sr-only" for="passuser"><% if Settings.password_reset_inputs != 'card_only' %>Username or <% end %>Card Number</label>
-                            <input type="text" class="form-control" id="passuser" name="passuser" placeholder="<% if Settings.password_reset_inputs != 'card_only' %>Username or <% end %>Card #" required>
+                            <input type="text" class="form-control" id="passuser" name="passuser" autocapitalize="none" autocorrect="off" placeholder="<% if Settings.password_reset_inputs != 'card_only' %>Username or <% end %>Card #" required>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Followup to #6 where we disabled autocomplete and autocapitalization
on the password reset request form: this commit makes the same
change to the actual form that users are most often presented with.